### PR TITLE
OCP-1718: Update consul flag for consul-template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .kitchen.local.yml
 *.swp
 Gemfile.lock
+.idea

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: Render consul-template template of breakerbox instances config
   shell: >
     {{ breakerbox_consul_template_bin }} \
-      -consul "{{ breakerbox_docker_consul_host }}:{{ breakerbox_docker_consul_port }}" \
+      -consul-addr "{{ breakerbox_docker_consul_host }}:{{ breakerbox_docker_consul_port }}" \
       -template "{{ breakerbox_docker_ctmpl_dir }}/instances.yml.ctmpl:{{ breakerbox_docker_conf_dir }}/instances.yml" \
       -once
   register: ctmpl


### PR DESCRIPTION
-consul is not supported in consul-template 0.19.4. -consul-addr is
supported in both consul-template 0.18.5 and consul-tmeplate 0.19.4 so
can be used while we upgrade

Tested on consul-template 0.19.4 and 0.18.5