### PR TITLE
OCP-1835: Add healthcheck option to breakerbox

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,8 @@ breakerbox_docker_consul_port: 8500
 breakerbox_docker_app_port: 8080
 breakerbox_docker_admin_port: 8081
 
+breakerbox_docker_consul_healthchecks: False
+
 breakerbox_docker_logging_level: INFO
 breakerbox_docker_archaius_override:
   turbineHostRetry: 1s

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,10 +26,17 @@
     dest: "{{ breakerbox_docker_conf_dir }}/breakerbox.yml"
   notify: Restart breakerbox
 
-- name: Create consul-template template file of breakerbox instances.yml config file
+- name: Create consul-template template file of breakerbox instances.yml config file, with healthchecks
   template: 
+    src:  "instances-healthcheck.yml.ctmpl.j2"
+    dest: "{{ breakerbox_docker_ctmpl_dir }}/instances.yml.ctmpl"
+  when: breakerbox_docker_consul_healthchecks
+
+- name: Create consul-template template file of breakerbox instances.yml config file, no healthchecks
+  template:
     src:  "instances.yml.ctmpl.j2"
     dest: "{{ breakerbox_docker_ctmpl_dir }}/instances.yml.ctmpl"
+  when: not breakerbox_docker_consul_healthchecks
 
 - name: Render consul-template template of breakerbox instances config
   shell: >

--- a/templates/instances-healthcheck.yml.ctmpl.j2
+++ b/templates/instances-healthcheck.yml.ctmpl.j2
@@ -1,0 +1,28 @@
+urlSuffix: /tenacity/metrics.stream
+clusters:
+{% for dashboard in breakerbox_docker_dashboards -%}
+
+{# Consul discover configuration #}
+{% if dashboard.service_name|default(false) -%}
+
+{% raw %}{{{% endraw %}if service "{{ dashboard.service_name }}" {% raw %}}}{% endraw %}
+  {{ dashboard.name }}:
+    instances:
+{% raw %}{{{% endraw %}range service "{{ dashboard.service_name }}" {% raw %}}}{% endraw %}
+      - {% raw %}{{.Address}}:{{.Port}}
+{{end}}{% endraw %}
+{% raw %}{{{% endraw %}else{% raw %}}}{% endraw %}
+
+# No service object found for {{ dashboard.service_name }}
+{% raw %}{{{% endraw %}end{% raw %}}}{% endraw %}
+
+{# Clusters #}
+{% elif dashboard.clusters|default([]) %}
+  {{ dashboard.name }}:
+    clusters:
+{% for cluster in dashboard.clusters %}
+      - {{ cluster }}
+{% endfor %}
+{% endif -%}
+
+{% endfor -%}

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -68,6 +68,7 @@
       - name: production
         clusters: [ jenkins, redis ]
     breakerbox_docker_maxConcurrentConnections: 50
+    breakerbox_docker_consul_healthchecks: True
 
   roles:
     - ansible-breakerbox-docker


### PR DESCRIPTION
Add option to include instances in instances.yml only if they are
healthy in consul. This will remove current breakerbox issues